### PR TITLE
Add om flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A Leinigen template to get started with figwheel.
 
     lein new figwheel hello-world
 
+### Options
+
+    `--om` Adds a bare bones Om app, including Sablono.
+    `--reagent` Adds a bare bones Reagent app.
+
+Include the options using `--` to separate them from Leiningens
+options, like so
+
+    lein new figwheel hello-world -- --om
+
 ## License
 
 Copyright © 2014 FIXME

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A Leinigen template to get started with figwheel.
 
 ### Options
 
-    `--om` Adds a bare bones Om app, including Sablono.
-    `--reagent` Adds a bare bones Reagent app.
+    --om 		Adds a bare bones Om app, including Sablono.
+    --reagent   Adds a bare bones Reagent app.
 
 Include the options using `--` to separate them from Leiningens
 options, like so

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject figwheel/lein-template "0.2.3"
+(defproject figwheel/lein-template "0.2.2"
   :description "A Leinigen template for figwheel"
   :url "https://github.com/bhauman/figwheel-template"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject figwheel/lein-template "0.2.2"
+(defproject figwheel/lein-template "0.2.3"
   :description "A Leinigen template for figwheel"
   :url "https://github.com/bhauman/figwheel-template"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/new/figwheel.clj
+++ b/src/leiningen/new/figwheel.clj
@@ -42,9 +42,9 @@
     (clean-opts valid-options opts) ;; Check options for errors
     (let [data {:name name
                 :sanitized (name-to-path name)
-                :app (om? opts)
+                :om? (om? opts)
                 :reagent? (reagent? opts)}]
-      (main/info "Generating fresh 'lein new' figwheel project!")
+      (main/info "Generating fresh 'lein new' figwheel project.")
       (->files data
                ["project.clj" (render "project.clj" data)]
                ["src/{{sanitized}}/core.cljs" (render "core.cljs" data)]

--- a/src/leiningen/new/figwheel.clj
+++ b/src/leiningen/new/figwheel.clj
@@ -4,15 +4,50 @@
 
 (def render (renderer "figwheel"))
 
+
+;; Check if om or reagent are in the options
+;; Copied from: https://github.com/plexus/chestnut/blob/master/src/leiningen/new/chestnut.clj
+
+(def valid-options
+  ["om" "reagent"])
+
+(doseq [opt valid-options]
+  (eval
+   `(defn ~(symbol (str opt "?")) [opts#]
+     (some #{~(str "--" opt)} opts#))))
+
+(defn clean-opts
+  "Takes the incoming options and compares them to the valid ones.
+   It aborts the process and spits an error if an invalid option is present
+   or both --om and --reagent where selected."
+  [valid-options opts]
+  (let [valid-opts (map (partial str "--") valid-options)]
+    (doseq [opt opts]
+      (if-not (some #{opt} valid-opts)
+        (apply main/abort "Unrecognized option:" opt ". Should be one of" valid-opts)))
+    (if (and (om? opts) (reagent? opts))
+      (main/abort "Both --om and --reagent where selected. Please choose one")
+      valid-opts)))
+
 (defn figwheel
-  "FIXME: write documentation"
-  [name]
-  (let [data {:name name
-              :sanitized (name-to-path name)}]
-    (main/info "Generating fresh 'lein new' figwheel project.")
-    (->files data
-             ["project.clj" (render "project.clj" data)]
-             ["src/{{sanitized}}/core.cljs" (render "core.cljs" data)]
-             ["resources/public/index.html" (render "index.html" data)]
-             ["resources/public/css/style.css" (render "style.css" data)]
-             [".gitignore" (render "gitignore" data)])))
+  "Takes a name and options with the form --option and produces an interactive
+   ClojureScript + Fighweel template.
+   The valid options are:
+     --om      which adds a minimal Om application in core.cljs
+     --reagent which adds a minimal Reagent application in core.cljs
+   Both options can't be specified at the same time. If no option is specified,
+   nothing but a print statment is added in core.cljs"
+  [name & opts]
+  (do
+    (clean-opts valid-options opts) ;; Check options for errors
+    (let [data {:name name
+                :sanitized (name-to-path name)
+                :app (om? opts)
+                :reagent? (reagent? opts)}]
+      (main/info "Generating fresh 'lein new' figwheel project!")
+      (->files data
+               ["project.clj" (render "project.clj" data)]
+               ["src/{{sanitized}}/core.cljs" (render "core.cljs" data)]
+               ["resources/public/index.html" (render "index.html" data)]
+               ["resources/public/css/style.css" (render "style.css" data)]
+               [".gitignore" (render "gitignore" data)]))))

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -32,9 +32,14 @@ To get an interactive development environment run:
 
     lein figwheel
 
-and open your browser at [localhost:3449](http://localhost:3449/)
+and open your browser at [localhost:3449](http://localhost:3449/).
+This will also auto compile and send all changes to the browser.
+After that you will get a Browser Connected REPL. An easy way to try
+it is:
 
-For more info, read [Waitin'](http://swannodette.github.io/2014/12/22/waitin/).
+    (js/alert "Am I connected?")
+
+and you should see an alert in the browser window.
 
 ## License
 

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -26,7 +26,7 @@ To clean all compiled files:
     lein clean
 
 The Clojurescript compiler can be slow sometimes. To help with that,
-irst-time Clojurescript developers, add the following to your bash
+first-time Clojurescript developers, add the following to your bash
 .profile:
 
     LEIN_FAST_TRAMPOLINE=y

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -8,7 +8,26 @@ FIXME: Write a paragraph about the library/project and highlight its goals.
 
 ## Setup
 
-First-time Clojurescript developers, add the following to your bash .profile:
+To get an interactive development environment run:
+
+    lein figwheel
+
+and open your browser at [localhost:3449](http://localhost:3449/).
+This will auto compile and send all changes to the browser without the
+need to reload. After the compilation process is complete, you will
+get a Browser Connected REPL. An easy way to try it is:
+
+    (js/alert "Am I connected?")
+
+and you should see an alert in the browser window.
+
+To clean all compiled files:
+
+    lein clean
+
+The Clojurescript compiler can be slow sometimes. To help with that,
+irst-time Clojurescript developers, add the following to your bash
+.profile:
 
     LEIN_FAST_TRAMPOLINE=y
     export LEIN_FAST_TRAMPOLINE
@@ -20,26 +39,7 @@ To avoid compiling ClojureScript for each build, AOT Clojurescript locally in yo
     user=> (compile 'cljs.closure)
     user=> (compile 'cljs.core)
 
-Subsequent builds can use:
-
-    lein cljsbuild auto
-
-Clean project specific out:
-
-    lein clean
-
-To get an interactive development environment run:
-
-    lein figwheel
-
-and open your browser at [localhost:3449](http://localhost:3449/).
-This will also auto compile and send all changes to the browser.
-After that you will get a Browser Connected REPL. An easy way to try
-it is:
-
-    (js/alert "Am I connected?")
-
-and you should see an alert in the browser window.
+For more info, read [Waitin'](http://swannodette.github.io/2014/12/22/waitin/).
 
 ## License
 

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -1,0 +1,43 @@
+# {{name}}
+
+FIXME: Write a one-line description of your library/project.
+
+## Overview
+
+FIXME: Write a paragraph about the library/project and highlight its goals.
+
+## Setup
+
+First-time Clojurescript developers, add the following to your bash .profile:
+
+    LEIN_FAST_TRAMPOLINE=y
+    export LEIN_FAST_TRAMPOLINE
+    alias cljsbuild="lein trampoline cljsbuild $@"
+
+To avoid compiling ClojureScript for each build, AOT Clojurescript locally in your project with the following:
+
+    lein trampoline run -m clojure.main
+    user=> (compile 'cljs.closure)
+    user=> (compile 'cljs.core)
+
+Subsequent builds can use:
+
+    lein cljsbuild auto
+
+Clean project specific out:
+
+    lein clean
+
+To get an interactive development environment run:
+
+    lein figwheel
+
+and open your browser at [localhost:3449](http://localhost:3449)
+
+For more info, read [Waitin'](http://swannodette.github.io/2014/12/22/waitin/).
+
+## License
+
+Copyright © 2014 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -25,22 +25,6 @@ To clean all compiled files:
 
     lein clean
 
-The Clojurescript compiler can be slow sometimes. To help with that,
-first-time Clojurescript developers, add the following to your bash
-.profile:
-
-    LEIN_FAST_TRAMPOLINE=y
-    export LEIN_FAST_TRAMPOLINE
-    alias cljsbuild="lein trampoline cljsbuild $@"
-
-To avoid compiling ClojureScript for each build, AOT Clojurescript locally in your project with the following:
-
-    lein trampoline run -m clojure.main
-    user=> (compile 'cljs.closure)
-    user=> (compile 'cljs.core)
-
-For more info, read [Waitin'](http://swannodette.github.io/2014/12/22/waitin/).
-
 ## License
 
 Copyright © 2014 FIXME

--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -32,7 +32,7 @@ To get an interactive development environment run:
 
     lein figwheel
 
-and open your browser at [localhost:3449](http://localhost:3449)
+and open your browser at [localhost:3449](http://localhost:3449/)
 
 For more info, read [Waitin'](http://swannodette.github.io/2014/12/22/waitin/).
 

--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -7,6 +7,10 @@
 
 (enable-console-print!)
 
+(println "Edits to this text should show up in your developer console.")
+
+;; define your app data so that it doesn't get over-written on reload
+
 (defonce app-state (atom {:text "Hello world!"}))
 {{#om?}}
 

--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -1,11 +1,14 @@
 (ns {{name}}.core
-    (:require [om.core :as om :include-macros true]
-              [om.dom :as dom :include-macros true]
-              [figwheel.client :as fw]))
+    (:require [figwheel.client :as fw] {{#om?}}
+              [om.core :as om :include-macros true]
+              [om.dom :as dom :include-macros true] {{/om?}} {{#reagent?}}
+              [reagent.core :as reagent :refer [atom]] {{/reagent?}}
+              ))
 
 (enable-console-print!)
 
-(def app-state (atom {:text "Hello world!"}))
+(defonce app-state (atom {:text "Hello world!"}))
+{{#om?}}
 
 (om/root
   (fn [app owner]
@@ -14,6 +17,13 @@
         (dom/h1 nil (:text app)))))
   app-state
   {:target (. js/document (getElementById "app"))})
+{{/om?}}{{#reagent?}}
+(defn hello-world []
+  [:h1 (:text @app-state)])
+
+(reagent/render-component [hello-world]
+                          (. js/document (getElementById "app")))
+{{/reagent?}}
 
 (fw/start {
   :on-jsload (fn []

--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -1,13 +1,19 @@
 (ns {{name}}.core
-  (:require
-    [figwheel.client :as fw]))
+    (:require [om.core :as om :include-macros true]
+              [om.dom :as dom :include-macros true]
+              [figwheel.client :as fw]))
 
 (enable-console-print!)
 
-;; define your app data so that it doesn't get over-written on reload
-;; (defonce app-data (atom {}))
+(def app-state (atom {:text "Hello world!"}))
 
-(println "Edits to this text should show up in your developer console.")
+(om/root
+  (fn [app owner]
+    (reify om/IRender
+      (render [_]
+        (dom/h1 nil (:text app)))))
+  app-state
+  {:target (. js/document (getElementById "app"))})
 
 (fw/start {
   :on-jsload (fn []

--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -1,9 +1,8 @@
 (ns {{name}}.core
-    (:require [figwheel.client :as fw] {{#om?}}
+    (:require [figwheel.client :as fw]{{#om?}}
               [om.core :as om :include-macros true]
-              [om.dom :as dom :include-macros true] {{/om?}} {{#reagent?}}
-              [reagent.core :as reagent :refer [atom]] {{/reagent?}}
-              ))
+              [om.dom :as dom :include-macros true]{{/om?}}{{#reagent?}}
+              [reagent.core :as reagent :refer [atom]]{{/reagent?}}))
 
 (enable-console-print!)
 

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link href="css/style.css" rel="stylesheet" type="text/css">
+    <link href="css/style.css" rel="stylesheet" type="text/css">{{#reagent?}}
+    <script src="http://fb.me/react-0.12.1.js"></script>{{/reagent?}}
   </head>
   <body>
-    <div id="app"></div>
+      <div id="app">
+          <h2>Figwheel template</h2>
+          <p>Checkout your developer console.</p>
+      </div>
     <script src="js/compiled/out/goog/base.js" type="text/javascript"></script>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>
     <script type="text/javascript">goog.require("{{ sanitized }}.core");</script>

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -6,8 +6,8 @@
   </head>
   <body>
       <div id="app">
-          <h2>Figwheel template</h2>
-          <p>Checkout your developer console.</p>
+        <h2>Figwheel template</h2>
+        <p>Checkout your developer console.</p>
       </div>
     <script src="js/compiled/out/goog/base.js" type="text/javascript"></script>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -4,10 +4,7 @@
     <link href="css/style.css" rel="stylesheet" type="text/css">
   </head>
   <body>
-    <div id="main-area">
-      <h2>Figwheel template</h2>
-      <p>Checkout your developer console.</p>
-    </div>
+    <div id="app"></div>
     <script src="js/compiled/out/goog/base.js" type="text/javascript"></script>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>
     <script type="text/javascript">goog.require("{{ sanitized }}.core");</script>

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -5,10 +5,10 @@
     <script src="http://fb.me/react-0.12.1.js"></script>{{/reagent?}}
   </head>
   <body>
-      <div id="app">
-        <h2>Figwheel template</h2>
-        <p>Checkout your developer console.</p>
-      </div>
+    <div id="app">
+      <h2>Figwheel template</h2>
+      <p>Checkout your developer console.</p>
+    </div>
     <script src="js/compiled/out/goog/base.js" type="text/javascript"></script>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>
     <script type="text/javascript">goog.require("{{ sanitized }}.core");</script>

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -7,9 +7,10 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-2727"]
                  [figwheel "0.2.2-SNAPSHOT"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [sablono "0.2.22"]
-                 [org.omcljs/om "0.8.6"]]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]{{#om?}}
+                 [org.omcljs/om "0.8.6"]{{/om?}}{{#reagent?}}
+                 [reagent "0.5.0-alpha"]{{/reagent?}}
+                 [sablono "0.2.22"]]
 
   :plugins [[lein-cljsbuild "1.0.4"]
             [lein-figwheel "0.2.2-SNAPSHOT"]]
@@ -17,23 +18,23 @@
   :source-paths ["src"]
   
   :cljsbuild {
-    :builds [{:id "dev"
-              :source-paths ["src"]
-              :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
-                         :output-dir "resources/public/js/compiled/out"
-                         :optimizations :none
-                         :source-map true
-                         :source-map-timestamp true
-                         :cache-analysis true }}
-             {:id "min"
-              :source-paths ["src"]
-              :compiler {:output-to "resources/public/{{sanitized}}.min.js"
-                         :optimizations :advanced
-                         :pretty-print false}}]}
+              :builds [{:id "dev"
+                        :source-paths ["src"]
+                        :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
+                                   :output-dir "resources/public/js/compiled/out"
+                                   :optimizations :none
+                                   :source-map true
+                                   :source-map-timestamp true
+                                   :cache-analysis true }}
+                       {:id "min"
+                        :source-paths ["src"]
+                        :compiler {:output-to "resources/public/{{sanitized}}.min.js"
+                                   :optimizations :advanced
+                                   :pretty-print false}}]}
 
   :figwheel {
              :http-server-root "public" ;; default and assumes "resources" 
-             :server-port 3449 ;; default
+             :server-port 3449          ;; default
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
              ;; Server Ring Handler (optional)

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -18,23 +18,23 @@
   :source-paths ["src"]
   
   :cljsbuild {
-              :builds [{:id "dev"
-                        :source-paths ["src"]
-                        :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
-                                   :output-dir "resources/public/js/compiled/out"
-                                   :optimizations :none
-                                   :source-map true
-                                   :source-map-timestamp true
-                                   :cache-analysis true }}
-                       {:id "min"
-                        :source-paths ["src"]
-                        :compiler {:output-to "resources/public/{{sanitized}}.min.js"
+    :builds [{:id "dev"
+              :source-paths ["src"]
+              :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
+                         :output-dir "resources/public/js/compiled/out"
+                         :optimizations :none
+                         :source-map true
+                         :source-map-timestamp true
+                         :cache-analysis true }}
+             {:id "min"
+              :source-paths ["src"]
+              :compiler {:output-to "resources/public/{{sanitized}}.min.js"
                                    :optimizations :advanced
                                    :pretty-print false}}]}
 
   :figwheel {
              :http-server-root "public" ;; default and assumes "resources" 
-             :server-port 3449          ;; default
+             :server-port 3449 ;; default
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
              ;; Server Ring Handler (optional)

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -8,9 +8,9 @@
                  [org.clojure/clojurescript "0.0-2727"]
                  [figwheel "0.2.2-SNAPSHOT"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]{{#om?}}
+                 [sablono "0.2.22"]
                  [org.omcljs/om "0.8.6"]{{/om?}}{{#reagent?}}
-                 [reagent "0.5.0-alpha"]{{/reagent?}}
-                 [sablono "0.2.22"]]
+                 [reagent "0.4.3"]{{/reagent?}}]
 
   :plugins [[lein-cljsbuild "1.0.4"]
             [lein-figwheel "0.2.2-SNAPSHOT"]]

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -29,8 +29,8 @@
              {:id "min"
               :source-paths ["src"]
               :compiler {:output-to "resources/public/{{sanitized}}.min.js"
-                                   :optimizations :advanced
-                                   :pretty-print false}}]}
+                         :optimizations :advanced
+                         :pretty-print false}}]}
 
   :figwheel {
              :http-server-root "public" ;; default and assumes "resources" 


### PR DESCRIPTION
I added both options, --om & --reagent as requested. They are documented in the README file for the project. There is also a new README for the template with instructions on how to run Figwheel. 

Let me know when you publish this to Clojars (if you do :) ), I plan to use this template for a small rewrite of the Om tutorials. 

Notes: on Reagent's next version 0.5.0, the <script facebook> won't be needed in index.html.