### PR TITLE
Added clean-targets to project.clj so that lein clean works properly

### DIFF
--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -16,6 +16,8 @@
             [lein-figwheel "0.2.2-SNAPSHOT"]]
 
   :source-paths ["src"]
+
+  :clean-targets ^{:protect false} ["resources/public/js/compiled"]
   
   :cljsbuild {
     :builds [{:id "dev"


### PR DESCRIPTION
Since `lein cljsbuild clean` is no longer supported (as of 1.4.0) and Figwheel is compiled to `resources/public/js/compiled`, an extra configuration is needed in `project.clj` so that `lean clean` also cleans Figwheels output.

Sorry, I missed this one in the last pull request.