### PR TITLE
Add assets path

### DIFF
--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -25,6 +25,13 @@ To clean all compiled files:
 
     lein clean
 
+To create a production build run:
+
+    lein cljsbuild once min
+
+And open your browser in `resources/public/index.html`. You will not
+get live reloading, nor a REPL. 
+
 ## License
 
 Copyright © 2014 FIXME

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -9,8 +9,6 @@
       <h2>Figwheel template</h2>
       <p>Checkout your developer console.</p>
     </div>
-    <script src="js/compiled/out/goog/base.js" type="text/javascript"></script>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>
-    <script type="text/javascript">goog.require("{{ sanitized }}.core");</script>
   </body>
 </html>

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -32,7 +32,7 @@
                          :cache-analysis true }}
              {:id "min"
               :source-paths ["src"]
-              :compiler {:output-to "resources/public/compiled/{{sanitized}}.js"
+              :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
                          :optimizations :advanced
                          :pretty-print false}}]}
 

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -25,6 +25,8 @@
               :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
                          :output-dir "resources/public/js/compiled/out"
                          :optimizations :none
+                         :main {{name}}.core
+                         :asset-path "js/compiled/out"
                          :source-map true
                          :source-map-timestamp true
                          :cache-analysis true }}

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -32,7 +32,7 @@
                          :cache-analysis true }}
              {:id "min"
               :source-paths ["src"]
-              :compiler {:output-to "resources/public/{{sanitized}}.min.js"
+              :compiler {:output-to "resources/public/compiled/{{sanitized}}.js"
                          :optimizations :advanced
                          :pretty-print false}}]}
 


### PR DESCRIPTION
Thanks for the pointer Bruce. Now there is no need to edit the markup when changing from `dev` to `min` builds.

Fixes issue #7 