### PR TITLE
Changed to data

### DIFF
--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -14,10 +14,10 @@
 {{#om?}}
 
 (om/root
-  (fn [app owner]
+  (fn [data owner]
     (reify om/IRender
       (render [_]
-        (dom/h1 nil (:text app)))))
+        (dom/h1 nil (:text data)))))
   app-state
   {:target (. js/document (getElementById "app"))})
 {{/om?}}{{#reagent?}}


### PR DESCRIPTION
Sorry to disturb... The folks at the Clojure Group thought that `app` was ambiguous and should be changed to `data` for the tutorial. It would be nice if it also started like that in the template.

Thanks!