### PR TITLE
Add unit testing support to the Figwheel template.

### DIFF
--- a/src/leiningen/new/figwheel.clj
+++ b/src/leiningen/new/figwheel.clj
@@ -49,6 +49,11 @@
                ["project.clj" (render "project.clj" data)]
                ["src/{{sanitized}}/core.cljs" (render "core.cljs" data)]
                ["dev_src/{{sanitized}}/dev.cljs" (render "dev_core.cljs" data)]
+               ["dev_src/{{sanitized}}/polyfill.js" (render "polyfill.js" data)]
+               ["dev_src/{{sanitized}}/unit-test.js" (render "unit-test.js" data)]
+               ["dev_src/{{sanitized}}/unit-test.html" (render "unit-test.html" data)]
+               ["test/cljs/{{sanitized}}/test_runner.cljs" (render "test_runner.cljs" data)]
+               ["test/cljs/{{sanitized}}/test_core.cljs" (render "test_core.cljs" data)]
                ["resources/public/index.html" (render "index.html" data)]
                ["resources/public/css/style.css" (render "style.css" data)]
                [".gitignore" (render "gitignore" data)]))))

--- a/src/leiningen/new/figwheel/core.cljs
+++ b/src/leiningen/new/figwheel/core.cljs
@@ -11,20 +11,19 @@
 
 (defonce app-state (atom {:text "Hello world!"}))
 {{#om?}}
-
-(om/root
-  (fn [data owner]
-    (reify om/IRender
-      (render [_]
-        (dom/h1 nil (:text data)))))
-  app-state
-  {:target (. js/document (getElementById "app"))})
+(defn main []
+  (om/root
+   (fn [data owner]
+     (reify om/IRender
+       (render [_]
+         (dom/h1 nil (:text data)))))
+   app-state
+   {:target (. js/document (getElementById "app"))}))
 {{/om?}}{{#reagent?}}
 (defn hello-world []
   [:h1 (:text @app-state)])
 
-(reagent/render-component [hello-world]
-                          (. js/document (getElementById "app")))
+(defn main []
+  (reagent/render-component [hello-world]
+                            (. js/document (getElementById "app"))))
 {{/reagent?}}
-
-

--- a/src/leiningen/new/figwheel/index.html
+++ b/src/leiningen/new/figwheel/index.html
@@ -9,5 +9,6 @@
       <p>Checkout your developer console.</p>
     </div>
     <script src="js/compiled/{{ sanitized }}.js" type="text/javascript"></script>
+    <script type="text/javascript">{{sanitized}}.core.main()</script>
   </body>
 </html>

--- a/src/leiningen/new/figwheel/polyfill.js
+++ b/src/leiningen/new/figwheel/polyfill.js
@@ -1,0 +1,24 @@
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP && oThis
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}

--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -18,27 +18,35 @@
   :source-paths ["src"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled"]
-  
+
   :cljsbuild {
-    :builds [{:id "dev"
-              :source-paths ["src" "dev_src"]
-              :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
-                         :output-dir "resources/public/js/compiled/out"
-                         :optimizations :none
-                         :main {{name}}.dev
-                         :asset-path "js/compiled/out"
-                         :source-map true
-                         :source-map-timestamp true
-                         :cache-analysis true }}
-             {:id "min"
-              :source-paths ["src"]
-              :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
-                         :main {{name}}.core                         
-                         :optimizations :advanced
-                         :pretty-print false}}]}
+              :test-commands ["phantomjs" "dev_src/{{sanitized}}/unit-test.js" "dev_src/{{sanitized}}/unit-test.html"]
+              :builds [{:id "dev"
+                        :source-paths ["src" "dev_src"]
+                        :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
+                                   :output-dir "resources/public/js/compiled/out"
+                                   :optimizations :none
+                                   :main {{name}}.dev
+                                   :asset-path "js/compiled/out"
+                                   :source-map true
+                                   :source-map-timestamp true
+                                   :cache-analysis true }}
+                       {:id "test"
+                        :source-paths ["src" "dev_src" "test/cljs"]
+                        :notify-command ["phantomjs" "dev_src/{{sanitized}}/unit-test.js" "dev_src/{{sanitized}}/unit-test.html"]
+                        :compiler {:output-to "resources/public/js/compiled/test_{{sanitized}}.js"
+                                   :output-dir "resources/public/js/compiled/test"
+                                   :optimizations :whitespace
+                                   :cache-analysis true }}
+                       {:id "min"
+                        :source-paths ["src"]
+                        :compiler {:output-to "resources/public/js/compiled/{{sanitized}}.js"
+                                   :main {{name}}.core
+                                   :optimizations :advanced
+                                   :pretty-print false}}]}
 
   :figwheel {
-             :http-server-root "public" ;; default and assumes "resources" 
+             :http-server-root "public" ;; default and assumes "resources"
              :server-port 3449 ;; default
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
@@ -64,5 +72,5 @@
              ;; :repl false
 
              ;; to configure a different figwheel logfile path
-             ;; :server-logfile "tmp/logs/figwheel-logfile.log" 
+             ;; :server-logfile "tmp/logs/figwheel-logfile.log"
              })

--- a/src/leiningen/new/figwheel/test_core.cljs
+++ b/src/leiningen/new/figwheel/test_core.cljs
@@ -1,0 +1,6 @@
+(ns {{name}}.test.core
+  (:require-macros [cljs.test :refer (is deftest testing)])
+  (:require [cljs.test]))
+
+(deftest dummyPasses
+  (is (= 1 1)))

--- a/src/leiningen/new/figwheel/test_runner.cljs
+++ b/src/leiningen/new/figwheel/test_runner.cljs
@@ -1,0 +1,14 @@
+(ns {{name}}.test-runner
+  (:require
+   [cljs.test :refer-macros [run-tests]]
+   [{{name}}.test.core]))
+
+
+(enable-console-print!)
+
+(defn runner []
+  (if (cljs.test/successful?
+       (run-tests
+        '{{name}}.test.core))
+    0
+    1))

--- a/src/leiningen/new/figwheel/unit-test.html
+++ b/src/leiningen/new/figwheel/unit-test.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <script src="polyfill.js" type="text/javascript"></script>
+    <script src="../../resources/public/js/compiled/test_{{sanitized}}.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/src/leiningen/new/figwheel/unit-test.js
+++ b/src/leiningen/new/figwheel/unit-test.js
@@ -1,0 +1,36 @@
+var page = require('webpage').create();
+var url = phantom.args[0];
+
+page.onConsoleMessage = function (message) {
+    console.log(message);
+};
+
+function exit(code) {
+    setTimeout(function(){ phantom.exit(code); }, 0);
+    phantom.onError = function(){};
+}
+
+console.log("Loading URL: " + url);
+
+page.open(url, function (status) {
+    if (status != "success") {
+        console.log('Failed to open ' + url);
+        phantom.exit(1);
+    }
+
+    console.log("Running test.");
+
+    var result = page.evaluate(function() {
+        return {{sanitized}}.test_runner.runner();
+    });
+
+    if (result != 0) {
+        console.log("*** Test failed! ***");
+        exit(1);
+    }
+    else {
+	console.log("Test succeeded.");
+	exit(0);
+    }
+
+});


### PR DESCRIPTION
I thought it'd be nice to include unit testing support by default now that CLJS has a core library for it.
So I did it :-) ....

Includes the necessary configuration in project.clj, plus supporting files, to allow the user to execute ```lein cljsbuild once test``` and have unit tests run in PhantomJS if it's installed.

I had to make one small compromise; running the unit tests naturally loads the core.cljs, which prior to my modifications caused Reagent / Om (if used) to trigger, because they were being called directly from the core NS.

I've changed core.cljs and index.html to explicitly call a main function when we're running normally - and not to call it when we're testing (unless the user expliclty does so) which prevents Om / Reagent erroring because they can't find the app root when we're running tests.

(The alternative would have been to add a <div id="app"> to the unit-test.html, but at that point we're taking control of where to root the app away from the developer)