### PR TITLE
Bump dependencies of libraries and plugins

### DIFF
--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -5,14 +5,14 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "0.0-3297"]
+                 [org.clojure/clojurescript "1.7.122"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]{{#om?}}
-                 [sablono "0.3.4"]
-                 [org.omcljs/om "0.8.8"]{{/om?}}{{#reagent?}}
+                 [sablono "0.3.6"]
+                 [org.omcljs/om "0.9.0"]{{/om?}}{{#reagent?}}
                  [reagent "0.5.0"]{{/reagent?}}]
 
-  :plugins [[lein-cljsbuild "1.0.5"]
-            [lein-figwheel "0.3.5"]]
+  :plugins [[lein-cljsbuild "1.1.0"]
+            [lein-figwheel "0.3.8"]]
 
   :source-paths ["src"]
 


### PR DESCRIPTION
Updated:

* org.clojure/clojurescript
* sablono
* org.omcljs/om
* lein-cljsbuild
* lein-figwheel