### PR TITLE
should lein clean before lein cljsbuild to production env

### DIFF
--- a/src/leiningen/new/figwheel/README.md
+++ b/src/leiningen/new/figwheel/README.md
@@ -27,7 +27,7 @@ To clean all compiled files:
 
 To create a production build run:
 
-    lein cljsbuild once min
+    lein do clean, cljsbuild once min
 
 And open your browser in `resources/public/index.html`. You will not
 get live reloading, nor a REPL. 


### PR DESCRIPTION
if we run `lein figwheel` and compiled js file in the target directory and then `lein cljsbuild once min` will do nothing.

<img width="373" alt="2016-01-14 11 48 01" src="https://cloud.githubusercontent.com/assets/6234553/12329058/66a92294-bb19-11e5-9d2d-53b12f29bc8b.png">

so must point out that we should `lein clean` before, to avoid some misunderstanding.

<img width="853" alt="2016-01-14 11 48 08" src="https://cloud.githubusercontent.com/assets/6234553/12329073/7a64e958-bb19-11e5-855f-0d682be6f090.png">

@bhauman 