### PR TITLE
Update templated cider-nrepl version

### DIFF
--- a/src/leiningen/new/figwheel/project.clj
+++ b/src/leiningen/new/figwheel/project.clj
@@ -109,8 +109,8 @@
                                   [cider/piggieback "0.3.1"]]
                    ;; need to add dev source path here to get user.clj loaded
                    :source-paths ["src" "dev"]
-                   ;; for CIDER
-                   ;; :plugins [[cider/cider-nrepl "0.12.0"]]
+                   ;; for CIDER. Note that you should use the snapshot version, so it matches with the elpa dependency.
+                   ;; :plugins [[cider/cider-nrepl "0.18.0-SNAPSHOT"]]
                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                    ;; need to add the compliled assets to the :clean-targets
                    :clean-targets ^{:protect false} ["resources/public/js/compiled"


### PR DESCRIPTION
This PR simply updates the suggested version number, making it more likely to suggest an up-to-date one.

Also starts suggesting snapshots. AFAICT it's the best practice, if I had set `1.7.0` I would see in Emacs:

`WARNING: CIDER's version (0.18.0-snapshot) does not match cider-nrepl's version (0.17.0). Things will break!`

Cheers - Victor